### PR TITLE
arm sigreturn

### DIFF
--- a/arch/arm/kernel/signal.c
+++ b/arch/arm/kernel/signal.c
@@ -45,7 +45,7 @@
 #define SWI_THUMB_SIGRETURN	(0xdf00 << 16 | 0x2700 | (__NR_sigreturn - __NR_SYSCALL_BASE))
 #define SWI_THUMB_RT_SIGRETURN	(0xdf00 << 16 | 0x2700 | (__NR_rt_sigreturn - __NR_SYSCALL_BASE))
 
-static const unsigned long sigreturn_codes[7] = {
+const unsigned long sigreturn_codes[7] = {
 	MOV_R7_NR_SIGRETURN,    SWI_SYS_SIGRETURN,    SWI_THUMB_SIGRETURN,
 	MOV_R7_NR_RT_SIGRETURN, SWI_SYS_RT_SIGRETURN, SWI_THUMB_RT_SIGRETURN,
 };

--- a/arch/arm/kernel/signal.h
+++ b/arch/arm/kernel/signal.h
@@ -10,4 +10,5 @@
 #define KERN_SIGRETURN_CODE	(CONFIG_VECTORS_BASE + 0x00000500)
 #define KERN_RESTART_CODE	(KERN_SIGRETURN_CODE + sizeof(sigreturn_codes))
 
+extern const unsigned long sigreturn_codes[7];
 extern const unsigned long syscall_restart_code[2];

--- a/arch/arm/kernel/traps.c
+++ b/arch/arm/kernel/traps.c
@@ -37,6 +37,8 @@
 
 #include <trace/events/exception.h>
 
+#include "signal.h"
+
 static const char *handler[]= { "prefetch abort", "data abort", "address exception", "interrupt" };
 
 #ifdef CONFIG_LGE_CRASH_HANDLER
@@ -857,6 +859,9 @@ void __init early_trap_init(void *vectors_base)
 	memcpy((void *)vectors + 0x1000, __stubs_start, __stubs_end - __stubs_start);
 
 	kuser_init(vectors_base);
+
+    memcpy((void *)(vectors + KERN_RESTART_CODE - CONFIG_VECTORS_BASE),
+           syscall_restart_code, sizeof(syscall_restart_code));
 
 	flush_icache_range(vectors, vectors + PAGE_SIZE * 2);
 	modify_domain(DOMAIN_USER, DOMAIN_CLIENT);


### PR DESCRIPTION
Commit b33ffa2 is broken, it is a wrongly backported version of 48be69a026b2c17350a5ef18a1959a919f60be7d. I am not sure why this (SIGILL) doesn't happen more often and hasn't affected you but just to be sure, and if you're fine with it, let's fix it :).
